### PR TITLE
Allow CoreOS update-engine to natively use new CoreOS Application::Groups

### DIFF
--- a/backend/src/api/api.go
+++ b/backend/src/api/api.go
@@ -77,6 +77,9 @@ func New(options ...func(*API) error) (*API, error) {
 		return nil, err
 	}
 
+	// Add the non-standard coreosGroups from DB
+	coreosGroupPopulate(api)
+
 	return api, nil
 }
 

--- a/backend/src/api/applications.go
+++ b/backend/src/api/applications.go
@@ -7,10 +7,6 @@ import (
 	"gopkg.in/mgutz/dat.v1"
 )
 
-const (
-	coreosAppID = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
-)
-
 // Application represents a CoreRoller application instance.
 type Application struct {
 	ID          string     `db:"id" json:"id"`

--- a/backend/src/api/coreos.go
+++ b/backend/src/api/coreos.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/mgutz/logxi/v1"
 )
@@ -81,9 +82,10 @@ func coreosGroupPopulate(api *API) {
 	}
 
 	for _, group := range groups {
-		if _, exist := coreosGroups[group.Name]; ! exist {
-			coreosLogger.Debug(f, "Adding group", group, "uuid", group.ID)
-			coreosGroups[group.Name] = group.ID
+		groupName := strings.ToLower(group.Name)
+		if _, exist := coreosGroups[groupName]; ! exist {
+			coreosLogger.Debug(f, "Adding group", groupName, "uuid", group.ID)
+			coreosGroups[groupName] = group.ID
 		}
 	}
 

--- a/backend/src/api/coreos.go
+++ b/backend/src/api/coreos.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/mgutz/logxi/v1"
+)
+
+const coreosAppID = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
+
+var (
+	coreosLogger = log.New("coreos")
+
+	coreosGroups = map[string]string{
+		"alpha":  "5b810680-e36a-4879-b98a-4f989e80b899",
+		"beta":   "3fe10490-dd73-4b49-b72a-28ac19acfcdc",
+		"stable": "9a2deb70-37be-4026-853f-bfdd6b347bbe",
+	}
+
+	coreosGroupsPopulated = false
+)
+
+// CoreosAppID getter for coreosAppID 
+func CoreosAppID() string {
+	return coreosAppID
+}
+
+// CoreosGroupID retrieves groupID from coreosGroups
+func CoreosGroupID(group string) (string, bool) {
+	uuid, ok := coreosGroups[group]
+
+	return uuid, ok
+}
+
+func coreosGroupAdd(group string, uuid string) error {
+	f := "GroupAdd"
+
+	coreosLogger.Debug(f, "group", group, "uuid", uuid)
+
+	if _, ok := coreosGroups[group]; ok {
+		err := "Cannot add new CoreOS group as it already exists"
+		coreosLogger.Warn(f, err)
+		return errors.New(err)
+	}
+
+	coreosGroups[group] = uuid
+
+	return nil
+}
+
+func coreosGroupDel(groupID string) error {
+	f := "GroupDel"
+	err := "Cannot delete non-existent CoreOS group"
+
+	coreosLogger.Debug(f, "groupID", groupID)
+
+	//Delete by group ID
+	for group, uuid := range coreosGroups {
+		if uuid == groupID {
+			coreosLogger.Debug(f, "group", group, "groupID", groupID)
+			delete(coreosGroups, group)
+			return nil
+		}
+	}
+
+	return errors.New(err)
+}
+
+func coreosGroupPopulate(api *API) {
+	if coreosGroupsPopulated {
+		return
+	}
+
+	f := "init"
+
+	coreosLogger.Debug(f)
+
+	groups, err := api.GetGroups(coreosAppID, 1, 1000)
+	if err != nil {
+		coreosLogger.Error(f, "api.GetGroups", err)
+	}
+
+	for _, group := range groups {
+		if _, exist := coreosGroups[group.Name]; ! exist {
+			coreosLogger.Debug(f, "Adding group", group, "uuid", group.ID)
+			coreosGroups[group.Name] = group.ID
+		}
+	}
+
+	coreosGroupsPopulated = true
+}

--- a/backend/src/api/groups.go
+++ b/backend/src/api/groups.go
@@ -94,6 +94,10 @@ func (api *API) AddGroup(group *Group) (*Group, error) {
 		Returning("*").
 		QueryStruct(group)
 
+	if err == nil {
+		coreosGroupAdd(group.Name, group.ID)
+	}
+
 	return group, err
 }
 
@@ -138,6 +142,10 @@ func (api *API) DeleteGroup(groupID string) error {
 
 	if err == nil && result.RowsAffected == 0 {
 		return ErrNoRowsAffected
+	}
+
+	if err == nil {
+		coreosGroupDel(groupID)
 	}
 
 	return err

--- a/backend/src/omaha/omaha.go
+++ b/backend/src/omaha/omaha.go
@@ -74,7 +74,7 @@ func (h *Handler) buildOmahaResponse(omahaReq *omahaSpec.Request, ip string) (*o
 		group := reqApp.Track
 		if reqAppUUID, err := uuid.FromString(reqApp.Id); err == nil {
 			if reqAppUUID.String() == coreosAppID {
-				if coreosGroupID, ok := coreosGroups[group]; ok {
+				if coreosGroupID, ok := api.CoreosGroupID(group); ok {
 					group = coreosGroupID
 				}
 			}

--- a/backend/src/omaha/omaha.go
+++ b/backend/src/omaha/omaha.go
@@ -16,12 +16,7 @@ import (
 var (
 	logger = log.New("omaha")
 
-	coreosAppID  = "e96281a6-d1af-4bde-9a0a-97b76e56dc57"
-	coreosGroups = map[string]string{
-		"alpha":  "5b810680-e36a-4879-b98a-4f989e80b899",
-		"beta":   "3fe10490-dd73-4b49-b72a-28ac19acfcdc",
-		"stable": "9a2deb70-37be-4026-853f-bfdd6b347bbe",
-	}
+	coreosAppID = api.CoreosAppID()
 
 	// ErrMalformedRequest error indicates that the omaha request it has
 	// received is malformed.

--- a/backend/src/syncer/syncer.go
+++ b/backend/src/syncer/syncer.go
@@ -16,9 +16,10 @@ import (
 	"gopkg.in/mgutz/dat.v1"
 )
 
+var coreosAppID string = "{" + api.CoreosAppID() + "}"
+
 const (
 	coreosUpdatesURL = "https://public.update.core-os.net/v1/update/"
-	coreosAppID      = "{e96281a6-d1af-4bde-9a0a-97b76e56dc57}"
 	checkFrequency   = 1 * time.Hour
 )
 


### PR DESCRIPTION
Centralize the CoreOS details so that new groups can be added/deleted which in turn will update the coreosGroups map.

This allows for the ability of adding the custom group name to the CoreOS /etc/coreos/update.conf thereby allowing CoreRoller to resolve it correctly in the omaha protocol handling
```
GROUP=<custom_name>
```
e.g. GROUP=*devel*

I tried to use the GROUP=*\<UUID\>* with update-engine, but found it didn't handle it properly with CoreOS OS updates.

*As an aside, I started learning Go about 3 weeks ago, so any critiques/mentoring is very much welcomed.*