### PR TITLE
Syncer: offline sync support

### DIFF
--- a/backend/src/syncer/syncer.go
+++ b/backend/src/syncer/syncer.go
@@ -72,10 +72,13 @@ func New(api *api.API) (*Syncer, error) {
 func (s *Syncer) Start() {
 	logger.Debug("syncer ready!")
 	checkCh := time.Tick(checkFrequency)
+	startup_checkCh := time.After(1 * time.Minute)
 
 L:
 	for {
 		select {
+		case <-startup_checkCh:
+			_ = s.checkForUpdates()
 		case <-checkCh:
 			_ = s.checkForUpdates()
 		case <-s.stopCh:


### PR DESCRIPTION
This adds support to the syncer for downloading coreos updates. This way coreroller can be used in environments where the machines to be updated don't have direct access to the internet but only to the update server.

If you wan't to turn on offline sync you need to set two environment variables:

The variable `CR_OFFLINE_SYNC_PATH` sets the path on the local filesystem where the coreos updates should be downloaded to. `CR_OFFLINE_SYNC_URL` sets the url under which the downloaded images are made available (using an external HTTP server). If either of the enironment variables is empty the offline sync feature is disabled.