### PR TITLE
backend/src/api: remove unused import and fix typo

### DIFF
--- a/backend/src/api/events.go
+++ b/backend/src/api/events.go
@@ -3,8 +3,6 @@ package api
 import (
 	"errors"
 	"time"
-
-	"gopkg.in/mgutz/dat.v1"
 )
 
 const (
@@ -143,7 +141,7 @@ func (api *API) triggerEventConsequences(instanceID, appID, groupID, lastUpdateV
 		return err
 	}
 
-	// TODO: should we also consider ResultSuccess in the next check? CoreOS ~ generic conflics?
+	// TODO: should we also consider ResultSuccess in the next check? CoreOS ~ generic conflicts?
 	if etype == EventUpdateComplete && result == ResultSuccessReboot {
 		_ = api.updateInstanceStatus(instanceID, appID, InstanceStatusComplete)
 


### PR DESCRIPTION
Fixes an unused import in the API package and corrects the only typo I saw in the Go report card.