### PR TITLE
Increased defaultPerPage pagination value to 500

### DIFF
--- a/backend/src/api/helpers.go
+++ b/backend/src/api/helpers.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	defaultPage    uint64 = 1
-	defaultPerPage uint64 = 25
+	defaultPerPage uint64 = 500
 )
 
 // validatePaginationParams validates the pagination parameters provided,


### PR DESCRIPTION
Frontend is not using pagination yet so the only entries displayed are
the ones within the defaultPerPage value. This was causing some issues
regarding instances not being listed, but it could affect some other
entities that rely on the same default value (apps, groups, etc).

Fixes #60