### PR TITLE
Ensure that we return text/xml as per the Omaha protocol

### DIFF
--- a/backend/src/cmd/rollerd/controller.go
+++ b/backend/src/cmd/rollerd/controller.go
@@ -656,6 +656,7 @@ func (ctl *controller) getActivity(c web.C, w http.ResponseWriter, r *http.Reque
 //
 
 func (ctl *controller) processOmahaRequest(c web.C, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/xml")
 	ctl.omahaHandler.Handle(r.Body, w, getRequestIP(r))
 }
 


### PR DESCRIPTION
This address https://github.com/coreroller/coreroller/issues/68 
which is to add `text/xml` as the content type for Omaha Requests. 

From my understanding it looks like every requests that is serviced via `processOmahaRequest` returns xml, if this is not the case we may have to adjust. 